### PR TITLE
Create Cateto_opuesto

### DIFF
--- a/Cateto_opuesto
+++ b/Cateto_opuesto
@@ -1,0 +1,8 @@
+import math
+hipotenusa=10
+print ("Cual es el angulo base?")
+angulo=int(input())
+rad=math.radians(angulo)
+seno=math.sin(rad)
+cateto_op=seno*hipotenusa
+print (f"El cateto opuesto es: {cateto_op:.1f}")


### PR DESCRIPTION
Ejercicios: Programas que requieren cálculos con funciones predefinidas Ejercicio 1

Escribe un programa que calcule la longitud del cateto opuesto de un triángulo rectángulo cuya hipotenusa es dada por el usuario y tiene un ángulo base de 30º

Usa la siguiente fórmula 

sin θ = cateto opuesto/hipotenusa

nota que:

tienes que despejar el valor del cateto opuesto en la fórmula tienes el ángulo en grados y la función sin de Python lo necesita en radianes, entonces también tienes que convertir el ángulo a radianes. Ejemplo

si la hipotenusa = 10

sin θ = cateto opuesto/10

0.5 = cateto opuesto/10

cateto opuesto = 0.5 * 10

cateto opuesto = 5